### PR TITLE
Allow assigning meeting license on synced users

### DIFF
--- a/TeamViewerADConnector/Internal/Configuration.ps1
+++ b/TeamViewerADConnector/Internal/Configuration.ps1
@@ -18,6 +18,7 @@ function Import-Configuration($filename) {
         UseSecondaryEmails          = $true
         EnableConditionalAccessSync = $false
         EnableUserGroupsSync        = $false
+        MeetingLicenseKey           = ''
     }
     if (Test-Path $filename) {
         $configuration = (Get-Content $filename | Out-String | ConvertFrom-Json)
@@ -48,4 +49,6 @@ function Confirm-Configuration($config) {
     if ($config.UseSsoCustomerId -And [string]::IsNullOrWhiteSpace($config.SsoCustomerId)) {
         Throw "The parameter 'SsoCustomerId' cannot be empty if 'UseSsoCustomerId' is configured."
     }
+    # Verify $config.MeetingLicenseKey is a valid guid
+    ![string]::IsNullOrWhiteSpace($config.MeetingLicenseKey) -And [guid]$config.MeetingLicenseKey | Out-Null
 }

--- a/TeamViewerADConnector/Internal/Sync.ps1
+++ b/TeamViewerADConnector/Internal/Sync.ps1
@@ -195,6 +195,9 @@ function Invoke-SyncUser($syncContext, $configuration, $progressHandler) {
                 if ($configuration.UseSsoCustomerId) {
                     $newUser.sso_customer_id = $configuration.SsoCustomerId;
                 }
+                if ($configuration.MeetingLicenseKey) {
+                    $newUser.meeting_license_key = $configuration.MeetingLicenseKey;
+                }
                 try {
                     $addedUser = (Add-TeamViewerUser $configuration.ApiToken $newUser)
                     $newUser.id = $addedUser.id

--- a/TeamViewerADConnector/Internal/TeamViewer.ps1
+++ b/TeamViewerADConnector/Internal/TeamViewer.ps1
@@ -52,7 +52,7 @@ function Add-TeamViewerUser($accessToken, $user) {
         Throw "Cannot create user! Missing required fields [$missingFields]!"
     }
     $payload = @{ }
-    @('email', 'password', 'permissions', 'name', 'language', 'sso_customer_id') | Where-Object { $user[$_] } | ForEach-Object { $payload[$_] = $user[$_] }
+    @('email', 'password', 'permissions', 'name', 'language', 'sso_customer_id', 'meeting_license_key') | Where-Object { $user[$_] } | ForEach-Object { $payload[$_] = $user[$_] }
     return Invoke-TeamViewerRestMethod -Uri "$tvApiBaseUrl/api/$tvApiVersion/users" -Method Post -Headers @{authorization = "Bearer $accessToken" } `
         -ContentType "application/json; charset=utf-8" -Body ([System.Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json)))
 }

--- a/Tests/TeamViewerADConnector/Internal/Configuration.Tests.ps1
+++ b/Tests/TeamViewerADConnector/Internal/Configuration.Tests.ps1
@@ -45,4 +45,21 @@ Describe 'Confirm-Configuration' {
         $inputData = @{ UseSsoCustomerId = $true; SsoCustomerId = '' }
         { Confirm-Configuration $inputData } | Should -Throw
     }
+
+    It 'Should throw if MeetingLicenseKey is set, but not a valid guid' -ForEach @(
+        @{ MeetingLicenseKey = '1234-5678-90' }
+        @{ MeetingLicenseKey = 'Core' }
+    ) {
+        $inputData = @{ MeetingLicenseKey = $MeetingLicenseKey; UseGeneratedPassword = $true }
+        { Confirm-Configuration $inputData } | Should -Throw
+    }
+
+    It 'Should not throw if MeetingLicenseKey is empty or valid guid' -ForEach @(
+        @{ MeetingLicenseKey = '4d00238a-9391-44cd-88ab-631194a97de5'}
+        @{ MeetingLicenseKey = '{3D4E067E-68DB-4E18-BAF6-146780DBA174}'}
+        @{ MeetingLicenseKey = ''}
+    ) {
+        $inputData = @{ MeetingLicenseKey = $MeetingLicenseKey; UseGeneratedPassword = $true }
+        { Confirm-Configuration $inputData } | Should -Not -Throw
+    }
 }

--- a/Tests/TeamViewerADConnector/Internal/Sync.Tests.ps1
+++ b/Tests/TeamViewerADConnector/Internal/Sync.Tests.ps1
@@ -248,6 +248,42 @@ Describe 'Invoke-SyncUser' {
         }
     }
 
+    Context 'Meeting License Key' {
+        BeforeAll {
+            $MeetingLicenseKey = '4d00238a-9391-44cd-88ab-631194a97de5'
+            $null = $MeetingLicenseKey
+        }
+
+        BeforeEach {
+            $configuration = @{
+                MeetingLicenseKey = $MeetingLicenseKey
+            }
+            $null = $configuration
+            $syncContext = @{
+                UsersActiveDirectory   = @(@{ Email = 'user1@example.test' })
+                UsersTeamViewerByEmail = @{ }
+            }
+            $null = $syncContext
+        }
+
+        It 'Should set meeting license on new user passed to Add-TeamViewerUser' {
+            Mock Add-TeamViewerUser { }
+
+            Invoke-SyncUser $syncContext $configuration { }
+            Assert-MockCalled Add-TeamViewerUser -Times 1 -Scope It `
+                -ParameterFilter { $user -And $user.meeting_license_key -eq $configuration.MeetingLicenseKey }
+        }
+
+        It 'Should not be set non-existent meeting license on new user passed to Add-TeamViewerUser' {
+            Mock Add-TeamViewerUser { }
+            $configuration.Remove('MeetingLicenseKey')
+
+            Invoke-SyncUser $syncContext $configuration { }
+            Assert-MockCalled Add-TeamViewerUser -Times 1 -Scope It `
+                -ParameterFilter { $user -And -Not $user.meeting_license_key }
+        }
+    }
+
     Context 'Secondary Email Addresses' {
         BeforeAll {
             Mock Add-TeamViewerUser { }

--- a/Tests/TeamViewerADConnector/Internal/TeamViewer.Tests.ps1
+++ b/Tests/TeamViewerADConnector/Internal/TeamViewer.Tests.ps1
@@ -142,6 +142,15 @@ Describe 'Add-TeamViewerUser' {
             $Headers -And $Headers.ContainsKey('authorization') -And $Headers.authorization -eq 'Bearer TestAccessToken'
         }
     }
+
+    It 'Should include meeting license key in rest call if present' -ForEach @(
+        @{ inputData = @{ 'name' = 'Test User 1'; 'email' = 'test1@example.test'; 'language' = 'en'; 'meeting_license_key' = '4d00238a-9391-44cd-88ab-631194a97de5' } }
+        @{ inputData = @{ 'name' = 'Test User 1'; 'email' = 'test1@example.test'; 'language' = 'en' }}
+    ) {
+        Add-TeamViewerUser 'TestAccessToken' $inputData
+        Assert-MockCalled Invoke-RestMethod -Times 1 -Scope It
+        ([System.Text.Encoding]::UTF8.GetString($lastMockParams.Body) | ConvertFrom-Json).meeting_license_key | Should -Be $inputData.meeting_license_key
+    }
 }
 
 Describe 'Edit-TeamViewerUser' {


### PR DESCRIPTION
Add new configuration property that specifies a Guid that represents a
valid TeamViewer Meeting license activation code. If set, the license
will automatically be activated on newly created company members.

Note: For this to work the license must already be activated on the
company profile and it must still have free organizer license slots,
else the set license will be silently ignored.

* Add optional 'MeetingLicenseKey' property to configuration.
* Forward set meeting license key to create member Web API call