### PR TITLE
Remove support for conditional access groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,6 @@ automatically asks for elevated rights (if required).
   user will also be taken into account when trying to map to a
   TeamViewer user.
 
-- Parameter `EnableConditionalAccessSync`:
-
-  If set to `true` the script attempts to synchronize the given AD groups and
-  their respective users with the directory groups for _conditional access_ in
-  TeamViewer. Those groups can then be used to restrict/allow TeamViewer
-  functionality for certain users.
-  The conditional access synchronization step runs after the user sync.
-  This option requires the API token to have additional permissions.
-  See point `ApiToken` above.
-
 - Parameter `EnableUserGroupsSync`:
 
   If set to `true` the script attempts to synchronize the given AD groups and
@@ -168,6 +158,10 @@ If configured, the secondary email addresses of AD users are also taken
 into account for the mapping between AD users and TeamViewer users.
 
 ## Changelog
+
+### [1.5.0]
+
+- Removed conditional access sync support.
 
 ### [1.4.1]
 

--- a/TeamViewerADConnector/Internal/Configuration.ps1
+++ b/TeamViewerADConnector/Internal/Configuration.ps1
@@ -16,7 +16,6 @@ function Import-Configuration($filename) {
         DeactivateUsers             = $true
         RecursiveGroups             = $true
         UseSecondaryEmails          = $true
-        EnableConditionalAccessSync = $false
         EnableUserGroupsSync        = $false
         MeetingLicenseKey           = ''
     }

--- a/TeamViewerADConnector/Internal/Forms/MainWindow.xaml
+++ b/TeamViewerADConnector/Internal/Forms/MainWindow.xaml
@@ -146,7 +146,6 @@ See file LICENSE
                                 <RowDefinition SharedSizeGroup="ConfigurationTabHeight" />
                             </Grid.RowDefinitions>
                             <StackPanel Margin="10">
-                                <CheckBox VerticalAlignment="Top" Margin="5" Content="{Binding L.EnableConditionalAccessSync}" IsChecked="{Binding ConfigurationData.EnableConditionalAccessSync}" />
                                 <CheckBox VerticalAlignment="Top" Margin="5" Content="{Binding L.EnableUserGroupsSync}" IsChecked="{Binding ConfigurationData.EnableUserGroupsSync}" />
                             </StackPanel>
                         </Grid>

--- a/TeamViewerADConnector/Internal/Localization/GraphicalUserInterface.de.json
+++ b/TeamViewerADConnector/Internal/Localization/GraphicalUserInterface.de.json
@@ -6,7 +6,6 @@
     "Apply": "Übernehmen",
     "Cancel": "Abbrechen",
     "DeactivateUsers": "TeamViewer Benutzer deaktivieren, die nicht Mitglied der AD Gruppen sind",
-    "EnableConditionalAccessSync": "TeamViewer Conditional Access Gruppen synchronisieren",
     "EnableUserGroupsSync": "TeamViewer Nutzergruppen synchronisieren",
     "FilterLogFiles": "Log Dateien (*.log)|*.log|Alle Dateien (*.*)|*.*",
     "Install": "Installieren",

--- a/TeamViewerADConnector/Internal/Localization/GraphicalUserInterface.en.json
+++ b/TeamViewerADConnector/Internal/Localization/GraphicalUserInterface.en.json
@@ -6,7 +6,6 @@
     "Apply": "Apply",
     "Cancel": "Cancel",
     "DeactivateUsers": "Deactivate TeamViewer users that are not member of the AD group",
-    "EnableConditionalAccessSync": "Enable TeamViewer Conditional Access group synchronization",
     "EnableUserGroupsSync": "Enable TeamViewer user groups synchronization",
     "FilterLogFiles": "Log files (*.log)|*.log|All files (*.*)|*.*",
     "Install": "Install",


### PR DESCRIPTION
Remove CA group sync.
Remove options in GUI for Conditional Access (CA) group sync.
Update documentation in ReadMe.md about former CA groups.
Update changelog.