### PR TITLE
Add environment switch for API token test

### DIFF
--- a/TeamViewerADConnector/Internal/GraphicalUserInterface.ps1
+++ b/TeamViewerADConnector/Internal/GraphicalUserInterface.ps1
@@ -244,6 +244,7 @@ function Invoke-GraphicalUserInterfaceConfiguration($configuration, [string] $cu
     # Click Handler Button "Test Token"
     $mainWindow.FindName('BtnTestToken').Add_Click( {
             try {
+                 Set-WebUriForEnvironment $mainWindow.DataContext.ConfigurationData
                  $tokenValid = (Invoke-TeamViewerPing -ApiToken (ConvertTo-SecureString $mainWindow.DataContext.ConfigurationData.ApiToken -AsPlainText -Force))
             }
             catch {


### PR DESCRIPTION
Before the token can be tested, we need to explicitly change the environment. As there was no save to the configuration, this was forgotten at first and is now added.