### PR TITLE
Force installation and check for installed TeamViewerPS module.

### DIFF
--- a/TeamViewerADConnector/Invoke-InstallTeamViewerPSModule.ps1
+++ b/TeamViewerADConnector/Invoke-InstallTeamViewerPSModule.ps1
@@ -3,9 +3,9 @@ param(
     [string]$ModuleName = 'TeamViewerPS'
 )
 
-if (-not (Get-Module -Name $ModuleName -ErrorAction SilentlyContinue)) {
+if (-not (Get-InstalledModule -Name $ModuleName -ErrorAction SilentlyContinue)) {
     try {
-        Import-Module -Name $ModuleName -ErrorAction Stop
+        Install-Module -Name $ModuleName -Force -ErrorAction Stop
         Write-Verbose "Module $Modulename was succesfully installed"
     }
     catch {


### PR DESCRIPTION
Force is required as we cannot have user interaction on the command line.
The check went for the modules and not installed modules list (those are different ones in PowerShell).